### PR TITLE
Fix KVS regex to correctly filter path-unsafe characters

### DIFF
--- a/src/regexs.js
+++ b/src/regexs.js
@@ -27,9 +27,10 @@ export const APIFY_PROXY_VALUE_REGEX = /^[\w._~]+$/;
  * "The following character sets are generally safe for use in key names:
  * - Alphanumeric characters [0-9a-zA-Z]
  * - Special characters !, -, _, ., *, ', (, and )"
- * Additionally we allow \ and / and limit the length to 256 characters (TODO: document this)
+ * However, some of those characters are not valid across Win/Unix OS.
+ * Therefore we allow only a subset and limit the length to 256 characters (TODO: document this)
  */
-export const KEY_VALUE_STORE_KEY_REGEX = /^([a-zA-Z0-9!\-_.*'()\\/]{1,256})$/;
+export const KEY_VALUE_STORE_KEY_REGEX = /^([a-zA-Z0-9!\-_.'()]{1,256})$/;
 
 // taken from https://github.com/shinnn/github-username-regex
 const GITHUB_REGEX_STR = '[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}';

--- a/test/regexs.js
+++ b/test/regexs.js
@@ -89,6 +89,29 @@ const tests = {
             '$',
         ],
     },
+
+    KEY_VALUE_STORE_KEY_REGEX: {
+        valid: [
+            'hello123',
+            '123hello',
+            'this_is_1-key',
+            'with(parens)',
+            ")(x_._-''",
+            '!!!',
+        ],
+        invalid: [
+            '#',
+            '"hello"',
+            '/foo/bar',
+            '\\foo\\bar',
+            'some.*',
+            'one&two',
+            'yes?',
+            'xx{no}xx',
+            'http://www.google.com',
+            'C:\\Windows',
+        ],
+    },
 };
 
 describe('regexps', () => {


### PR DESCRIPTION
A supplemental change that is needed for fixing https://github.com/apifytech/apify-js/issues/123
PR: https://github.com/apifytech/apify-js/pull/125

It also fixes Jira:AP-477

_It's a breaking change_