### PR TITLE
Add helper function to serialize, compress and chunk data to be transferred over network 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -451,21 +451,17 @@ const gzipP = Promise.promisify(gzip);
 exports.stringifyGzipChunkArray = function stringifyGzipChunkArray(array, maxChunkSizeBytes) { // using "function" to be able to self-reference
     if (!array.length) return [];
     const serialized = JSON.stringify(array);
-    return gzip(serialized).then((zipped) => {
+    return gzipP(serialized).then((zipped) => {
         const byteSize = Buffer.byteLength(zipped);
         // return fast if size is ok
         if (byteSize < maxChunkSizeBytes) return [zipped];
         // now we know that it isn't, first check if we can do anything about it
-        if (array.length === 1) throw new Error(`Unable to serialize: Chunk too large! Item on index: 0 is ${byteSize} bytes.`); // eslint-disable-line
+        if (array.length === 1) throw new Error(`Unable to serialize: Chunk too large! Item is ${byteSize} bytes. Limit is ${maxChunkSizeBytes} bytes.`); // eslint-disable-line
         if (array.length > 1 && Math.ceil(byteSize / array.length) > maxChunkSizeBytes) throw new Error(`Unable to serialize: Data too large! Array cannot be split into chunks < ${maxChunkSizeBytes} bytes.`); // eslint-disable-line
         // theoretically possible to chunk now, let's assume that all items are roughly equal in size
         const numOfChunks = Math.ceil(byteSize / maxChunkSizeBytes);
         const maxItemsPerChunk = Math.floor(array.length / numOfChunks);
-        const chunked = array.reduce((newArray, item, itemIndex) => {
-            const chunkIndex = Math.floor(itemIndex / maxItemsPerChunk);
-            newArray[chunkIndex] = [].concat((newArray[chunkIndex] || []), item);
-            return newArray;
-        }, []);
+        const chunked = _.chunk(array, maxItemsPerChunk);
         // attempt to serialize the chunks
         const zipPromises = chunked.map(chunk => stringifyGzipChunkArray(chunk, maxChunkSizeBytes));
         return Promise.all(zipPromises)
@@ -473,14 +469,12 @@ exports.stringifyGzipChunkArray = function stringifyGzipChunkArray(array, maxChu
                 // throw on unexpected errors
                 if (!err.message.startsWith('Unable to serialize: ')) throw err;
                 // if it still doesn't work, try serialization one by one
-                const singlePromises = array.map(item => stringifyGzipChunkArray(item, maxChunkSizeBytes));
-                return Promise.all(singlePromises)
-                    .catch((err2) => {
-                        // throw on unexpected errors
-                        if (!err2.message.startsWith('Unable to serialize: ')) throw err;
-                        // everything failed
-                        throw new Error('Unable to serialize: Chunk too large! Items on indexes: TODO');
-                    });
-            });
+                const singlePromises = array.map((item) => {
+                    const wrapped = Array.isArray(item) ? item : [item];
+                    return stringifyGzipChunkArray(wrapped, maxChunkSizeBytes);
+                });
+                return Promise.all(singlePromises);
+            })
+            .then(results => [].concat(...results));
     });
 };

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,6 +1,9 @@
 import { assert, expect } from 'chai';
 import _ from 'underscore';
 import * as http from 'http';
+import { gunzip } from 'zlib';
+import { randomBytes } from 'crypto';
+import Promise from 'bluebird';
 import utils from '../build/utilities';
 
 describe('utilities', () => {
@@ -240,7 +243,13 @@ describe('utilities', () => {
             });
     });
 
-    describe('stringifyGzipChunkArray', () => {
+    describe('stringifyGzipChunkArray()', () => {
+        const gunzipP = Promise.promisify(gunzip);
+        const randomBytesP = Promise.promisify(randomBytes);
+        let expected;
+        const rD = size => randomBytesP(size || 1000).then(buf => buf.toString());
+        const data = [rD(), rD(), rD(), rD(), rD()];
+
         it('serializes simple input', () => {
             const input = [
                 1,
@@ -249,6 +258,102 @@ describe('utilities', () => {
                 false,
                 null,
             ];
+
+            return utils
+                .stringifyGzipChunkArray(input, 1000)
+                .then(zipped => gunzipP(zipped[0]))
+                .then((unzipped) => {
+                    const string = unzipped.toString();
+                    const parsed = JSON.parse(string);
+                    expect(parsed).to.be.an('array');
+                    expect(parsed).to.deep.eql(input);
+                    expect(string).to.be.eql(JSON.stringify(input));
+                });
+        });
+        it('serializes large input into smaller chunks', () => {
+            return Promise.all(data)
+                .then((input) => {
+                    expected = input;
+                    return utils.stringifyGzipChunkArray(input, 4000);
+                })
+                .then(zipped => Promise.all(zipped.map(chunk => gunzipP(chunk))))
+                .then((unzipped) => {
+                    const parsedData = unzipped.map(buf => JSON.parse(buf.toString()));
+                    parsedData.forEach(item => expect(item).to.be.an('array'));
+                    const rebuilt = [].concat(...parsedData);
+                    expect(rebuilt).to.be.eql(expected);
+                });
+        });
+        it('serializes large input into individual chunks', () => {
+            return Promise.all(data)
+                .then((input) => {
+                    expected = input;
+                    return utils.stringifyGzipChunkArray(input, 1800);
+                })
+                .then(zipped => Promise.all(zipped.map(chunk => gunzipP(chunk))))
+                .then((unzipped) => {
+                    const parsedData = unzipped.map(buf => JSON.parse(buf.toString()));
+                    parsedData.forEach(item => expect(item).to.be.an('array'));
+                    const rebuilt = [].concat(...parsedData);
+                    expect(rebuilt).to.be.eql(expected);
+                });
+        });
+        it('fails to serialize when one chunk is too large', () => {
+            data.push(rD(2000));
+            return Promise.all(data)
+                .then((input) => {
+                    expected = input;
+                    return utils.stringifyGzipChunkArray(input, 1500);
+                })
+                .then(() => {
+                    throw new Error('Should fail');
+                }, (err) => {
+                    expect(err).to.be.an('error');
+                    expect(err.message).to.include('Chunk too large!');
+                });
+        });
+        it('fails to serialize large input chunks', () => {
+            return Promise.all(data)
+                .then((input) => {
+                    expected = input;
+                    return utils.stringifyGzipChunkArray(input, 800);
+                })
+                .then(() => {
+                    throw new Error('Should fail');
+                }, (err) => {
+                    expect(err).to.be.an('error');
+                    expect(err.message).to.include('Data too large!');
+                });
+        });
+        it('serializes complex structures correctly', () => {
+            const first = {
+                one: 'two',
+                three: [
+                    'four',
+                    {
+                        five: [6, 7, 8],
+                    },
+                ],
+                nine: {
+                    ten: 'eleven',
+                },
+            };
+            const second = [1, 2, 3, ['four', [5, 6], { seven: 8 }], 'nine'];
+            const third = [rD(2), rD(3), rD(10)];
+
+            return Promise.all(third)
+                .then((t) => {
+                    const input = [first, t, second, [], {}, null];
+                    expected = input;
+                    return utils.stringifyGzipChunkArray(input, 130);
+                })
+                .then(zipped => Promise.all(zipped.map(chunk => gunzipP(chunk))))
+                .then((unzipped) => {
+                    const parsedData = unzipped.map(buf => JSON.parse(buf.toString()));
+                    parsedData.forEach(item => expect(item).to.be.an('array'));
+                    const rebuilt = [].concat(...parsedData);
+                    expect(rebuilt).to.be.eql(expected);
+                });
         });
     });
 });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -239,4 +239,16 @@ describe('utilities', () => {
                 });
             });
     });
+
+    describe('stringifyGzipChunkArray', () => {
+        it('serializes simple input', () => {
+            const input = [
+                1,
+                'two',
+                { three: 'four' },
+                false,
+                null,
+            ];
+        });
+    });
 });


### PR DESCRIPTION
Implements https://github.com/apifytech/apify-js/issues/70 as a helper function that will initially be used in `apify-client/datasets`.

