### PR TITLE
Add MAX_PAYLOAD_SIZE_BYTES = 9MB constant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [

--- a/src/consts.js
+++ b/src/consts.js
@@ -304,3 +304,8 @@ export const CUSTOMER_REQUEST_TYPES = {
     OTHER: 'OTHER',
 };
 
+/**
+ * Represents the maximum size in bytes of a request body (decompressed)
+ * that will be accepted by the App and API servers.
+ */
+export const MAX_PAYLOAD_SIZE_BYTES = 9437184; // 9MB


### PR DESCRIPTION
Enables chunking of data pushed to datasets, see https://github.com/apifytech/apify-js/pull/138