### PR TITLE
Add WebhookPayloadTemplate class to handle curly braces webhook syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
   "rules": {
     "indent": ["error", 4, { "SwitchCase": 1 }],
     "no-underscore-dangle": [2, {
-      "allow": ["_id", "_overrideMethodGroups"]
+      "allow": ["_id", "_overrideMethodGroups"],
+      "allowAfterThis": true
     }],
     "no-use-before-define": 0,
     "no-param-reassign": 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.1.44 / 2019-05-09
+===================
+- Renamed `JsonToken` to `JsonVariable`.
+- 
+
 0.1.43 / 2019-05-07
 ===================
 - Added `jsonStringifyExtended()` and `JsonToken` class to client utils.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [

--- a/src/webhook_payload_template.js
+++ b/src/webhook_payload_template.js
@@ -36,6 +36,7 @@ const { JsonToken, jsonStringifyExtended } = require('./utilities.client');
  *    }
  * }
  * ```
+ * @hideconstructor
  */
 export default class WebhookPayloadTemplate {
     constructor(payloadTemplate, allowedVariables = null, context = {}) {
@@ -54,8 +55,8 @@ export default class WebhookPayloadTemplate {
      * Parse also validates the template structure, so it can be used
      * to check validity of the template JSON and usage of allowedVariables.
      * @param {string} payloadTemplate
-     * @param {Set<string>|null} [allowedVariables]
-     * @param {Object} [context]
+     * @param {Set<string>|null} [allowedVariables=null]
+     * @param {Object} [context={}]
      * @return {object}
      */
     static parse(payloadTemplate, allowedVariables, context) {
@@ -70,12 +71,14 @@ export default class WebhookPayloadTemplate {
      * Values created using `getTemplateVariable('foo.bar')`
      * will be stringified to `{{foo.bar}}` template variable.
      * @param {Object} objectTemplate
+     * @param {Function} [replacer]
+     * @param {number} [indent]
      * @return {string}
      */
-    static stringify(objectTemplate) {
+    static stringify(objectTemplate, replacer, indent) {
         const type = typeof objectTemplate;
         if (!objectTemplate || type !== 'object') throw new Error(`Cannot stringify a ${type} payload template.`);
-        return jsonStringifyExtended(objectTemplate);
+        return jsonStringifyExtended(objectTemplate, replacer, indent);
     }
 
     /**

--- a/src/webhook_payload_template.js
+++ b/src/webhook_payload_template.js
@@ -1,0 +1,163 @@
+const { JsonToken, jsonStringifyExtended } = require('./utilities.client');
+
+/**
+ * WebhookPayloadTemplate enables creation and parsing of webhook payload template strings.
+ * Template strings are JSON that may include template variables enclosed in double
+ * curly brackets: `{{variable}}`. When the template is parsed, variables are replaced
+ * with values from a provided context.
+ *
+ * This is useful to create dynamic webhook payloads where a template is saved on webhook
+ * creation and then variables are dynamically added on webhook dispatch.
+ *
+ * **Example:**
+ * ```js
+ * const payloadTemplate = `{
+ *    "id": "some-id",
+ *    "createdAt": "2019-05-08T15:22:21.095Z",
+ *    "dataToSend": {{data}}
+ * }`
+ *
+ * const data = {
+ *     status: 200,
+ *     body: 'hello world'
+ * }
+ *
+ * const payloadObject = WebhookPayloadTemplate.parse(payloadTemplate, null, { data })
+ * ```
+ *
+ * **Produces:**
+ * ```js
+ * {
+ *     id: "some-id",
+ *    createdAt: '2019-05-08T15:22:21.095Z',
+ *    dataToSend: {
+ *        status: 200,
+ *        body: 'hello world'
+ *    }
+ * }
+ * ```
+ */
+export default class WebhookPayloadTemplate {
+    constructor(payloadTemplate, allowedVariables = null, context = {}) {
+        this.template = payloadTemplate;
+        this.allowedVariables = allowedVariables;
+        this.context = context;
+
+        this.payload = this.template;
+        this.replacedVariables = [];
+    }
+
+    /**
+     * Parse existing webhook payload template string into an object, replacing
+     * template variables using the provided context.
+     *
+     * Parse also validates the template structure, so it can be used
+     * to check validity of the template JSON and usage of allowedVariables.
+     * @param {string} payloadTemplate
+     * @param {Set<string>|null} [allowedVariables]
+     * @param {Object} [context]
+     * @return {object}
+     */
+    static parse(payloadTemplate, allowedVariables, context) {
+        if (typeof payloadTemplate !== 'string') throw new Error('Cannot parse an object payload template.');
+        const template = new WebhookPayloadTemplate(payloadTemplate, allowedVariables, context);
+        return template._parse(); // eslint-disable-line no-underscore-dangle
+    }
+
+    /**
+     * Stringify an object into a webhook payload template.
+     * Values created using `getTemplateVariable('foo.bar')`
+     * will be stringified to `{{foo.bar}}` template variable.
+     * @param {Object} objectTemplate
+     * @return {string}
+     */
+    static stringify(objectTemplate) {
+        const type = typeof objectTemplate;
+        if (!objectTemplate || type !== 'object') throw new Error(`Cannot stringify a ${type} payload template.`);
+        return jsonStringifyExtended(objectTemplate);
+    }
+
+    /**
+     * Produces an instance of a template variable that can be used
+     * in objects and will be stringified into `{{variable}}` syntax.
+     *
+     * **Example:**
+     * ```js
+     * const resourceVariable = WebhookPayloadTemplate.getVariable('resource');
+     * const objectTemplate = {
+     *     foo: 'foo',
+     *     bar: ['bar'],
+     *     res: resourceVariable,
+     * }
+     *
+     * const payloadTemplate = WebhookPayloadTemplate.stringify(objectTemplate);
+     * ```
+     *
+     * **Produces:**
+     * ```json
+     * {
+     *     "foo": "foo",
+     *     "bar": ["bar"],
+     *     "res": {{resource}},
+     * }
+     * ```
+     *
+     * @param {string} variable
+     * @return {JsonToken}
+     */
+    static getVariable(variable) {
+        return new JsonToken(variable);
+    }
+
+    /** @private */
+    _parse() {
+        while (true) { // eslint-disable-line no-constant-condition
+            try {
+                return JSON.parse(this.payload);
+            } catch (err) {
+                const index = this._parseIndexFromErrorMessage(err);
+                if (this._isErrorCausedByVariable(index)) {
+                    this._replaceVariable(index);
+                } else {
+                    throw err;
+                }
+            }
+        }
+    }
+
+    /** @private */
+    _parseIndexFromErrorMessage(err) { // eslint-disable-line class-methods-use-this
+        const errorPosition = err.message.match(/(\d+)$/)[0];
+        return Number(errorPosition);
+    }
+
+    /** @private */
+    _isErrorCausedByVariable(errorIndex) {
+        return this.payload[errorIndex - 1] === '{';
+    }
+
+    /** @private */
+    _replaceVariable(startIndex) {
+        const nextClosingBracesIndex = this.payload.indexOf('}}', startIndex);
+        const variable = this.payload.substring(startIndex + 1, nextClosingBracesIndex);
+        this._validateVariable(variable);
+        const replacement = this._getVariableReplacement(variable);
+        this.replacedVariables.push({ variable, replacement });
+        this.payload = this.payload.replace(`{{${variable}}}`, replacement);
+    }
+
+    /** @private */
+    _validateVariable(variable) {
+        if (this.allowedVariables === null) return;
+        const isVariableValid = this.allowedVariables.has(variable);
+        if (!isVariableValid) throw new Error(`Invalid payload template variable: ${variable}`);
+    }
+
+    /** @private */
+    _getVariableReplacement(variable) {
+        const replacement = this.context[variable];
+        return replacement
+            ? JSON.stringify(replacement)
+            : null;
+    }
+}

--- a/src/webhook_payload_template.js
+++ b/src/webhook_payload_template.js
@@ -72,10 +72,10 @@ export default class WebhookPayloadTemplate {
      * will be stringified to `{{foo.bar}}` template variable.
      * @param {Object} objectTemplate
      * @param {Function} [replacer]
-     * @param {number} [indent]
+     * @param {number} [indent=2]
      * @return {string}
      */
-    static stringify(objectTemplate, replacer, indent) {
+    static stringify(objectTemplate, replacer, indent = 2) {
         const type = typeof objectTemplate;
         if (!objectTemplate || type !== 'object') throw new Error(`Cannot stringify a ${type} payload template.`);
         return jsonStringifyExtended(objectTemplate, replacer, indent);

--- a/src/webhook_payload_template.js
+++ b/src/webhook_payload_template.js
@@ -59,7 +59,8 @@ export default class WebhookPayloadTemplate {
      * @return {object}
      */
     static parse(payloadTemplate, allowedVariables, context) {
-        if (typeof payloadTemplate !== 'string') throw new Error('Cannot parse an object payload template.');
+        const type = typeof payloadTemplate;
+        if (type !== 'string') throw new Error(`Cannot parse a ${type} payload template.`);
         const template = new WebhookPayloadTemplate(payloadTemplate, allowedVariables, context);
         return template._parse(); // eslint-disable-line no-underscore-dangle
     }

--- a/src/webhook_payload_template.js
+++ b/src/webhook_payload_template.js
@@ -1,4 +1,4 @@
-const { JsonToken, jsonStringifyExtended } = require('./utilities.client');
+const { JsonVariable, jsonStringifyExtended } = require('./utilities.client');
 
 /**
  * WebhookPayloadTemplate enables creation and parsing of webhook payload template strings.
@@ -107,10 +107,10 @@ export default class WebhookPayloadTemplate {
      * ```
      *
      * @param {string} variable
-     * @return {JsonToken}
+     * @return {JsonVariable}
      */
     static getVariable(variable) {
-        return new JsonToken(variable);
+        return new JsonVariable(variable);
     }
 
     /** @private */

--- a/test/webhook_payload_template.js
+++ b/test/webhook_payload_template.js
@@ -1,0 +1,89 @@
+import { expect } from 'chai';
+import WebhookPayloadTemplate from '../build/webhook_payload_template';
+
+const validJson = `
+{
+    "id": "some-id",
+    "createdAt": "2019-05-08T15:22:21.095Z",
+    "dataToSend": "{{data}}"
+}
+`;
+
+const validTemplate = `
+{
+    "userId": [{{userId}}],
+    "eventType": {{eventType}},
+    "createdAt": {{createdAt}},
+    "eventData": [{ "tmpl": {{eventData}} }],
+    "resource": {{resource}}
+}
+`;
+
+const invalidJson = `
+{
+    "id": "some-id",
+    "createdAt": "2019-05-08T15:22:21.095Z",,
+    "dataToSend": "{{data}}"
+}
+`;
+
+describe('WebhookPayloadTemplate', () => {
+    it('should parse template without variables', () => {
+        const payload = WebhookPayloadTemplate.parse(validJson);
+        expect(payload).to.be.eql({
+            id: 'some-id',
+            createdAt: '2019-05-08T15:22:21.095Z',
+            dataToSend: '{{data}}',
+        });
+    });
+    it('should parse template with variables', () => {
+        const payload = WebhookPayloadTemplate.parse(validTemplate);
+        expect(payload).to.be.eql({
+            userId: [null],
+            eventType: null,
+            createdAt: null,
+            eventData: [{ tmpl: null }],
+            resource: null,
+        });
+    });
+    it('should fill template with variables using context', () => {
+        const context = {
+            userId: 'some-user-id',
+            eventData: {
+                status: 200,
+                body: 'hello-world',
+                messages: [1, 2, 3],
+            },
+        };
+        const payload = WebhookPayloadTemplate.parse(validTemplate, null, context);
+        expect(payload).to.be.eql({
+            userId: ['some-user-id'],
+            eventType: null,
+            createdAt: null,
+            eventData: [{
+                tmpl: {
+                    status: 200,
+                    body: 'hello-world',
+                    messages: [1, 2, 3],
+                } }],
+            resource: null,
+        });
+    });
+    it('should throw on invalid json', () => {
+        try {
+            WebhookPayloadTemplate.parse(invalidJson);
+            throw new Error('Wrong error.');
+        } catch (err) {
+            expect(err.message).to.be.eql('Unexpected token , in JSON at position 68');
+        }
+    });
+    it('should throw on invalid variable', () => {
+        const allowedVars = new Set(['userId', 'eventData']);
+        try {
+            WebhookPayloadTemplate.parse(validTemplate, allowedVars);
+            throw new Error('Wrong error.');
+        } catch (err) {
+            expect(err.message).to.be.eql('Invalid payload template variable: eventType');
+        }
+    });
+});

--- a/test/webhook_payload_template.js
+++ b/test/webhook_payload_template.js
@@ -86,4 +86,19 @@ describe('WebhookPayloadTemplate', () => {
             expect(err.message).to.be.eql('Invalid payload template variable: eventType');
         }
     });
+    it('should stringify object payload templates', () => {
+        const numVar = WebhookPayloadTemplate.getVariable('num');
+        const bodyVar = WebhookPayloadTemplate.getVariable('body');
+        const objTemplate = {
+            hello: 'world',
+            num: numVar,
+            data: {
+                status: 304,
+                body: bodyVar,
+            },
+        };
+
+        const payloadTemplate = WebhookPayloadTemplate.stringify(objTemplate);
+        expect(payloadTemplate).to.be.eql('{"hello":"world","num":{{num}},"data":{"status":304,"body":{{body}}}}');
+    });
 });

--- a/test/webhook_payload_template.js
+++ b/test/webhook_payload_template.js
@@ -98,7 +98,7 @@ describe('WebhookPayloadTemplate', () => {
             },
         };
 
-        const payloadTemplate = WebhookPayloadTemplate.stringify(objTemplate);
+        const payloadTemplate = WebhookPayloadTemplate.stringify(objTemplate, null, 0);
         expect(payloadTemplate).to.be.eql('{"hello":"world","num":{{num}},"data":{"status":304,"body":{{body}}}}');
     });
 });


### PR DESCRIPTION
Title says all. Putting it here since it's gonna be useful in SDK too when creating webhooks programmatically.

Currently does not support dot notation `{{var.prop}}`, but I'll add it later.