### PR TITLE
Implement webhook template dot notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 0.1.50 / 2019-05-16
 ===================
+- Add support of dot notation (`resource.id`) to `WebhookPayloadTemplate`.
+
+0.1.50 / 2019-05-16
+===================
 - Fix `WebhookPayloadTemplateError` `captureStackTrace` error in environments without support.
 
 0.1.49 / 2019-05-16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-shared",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "description": "Tools and constants shared across Apify projects.",
   "main": "build/index.js",
   "keywords": [


### PR DESCRIPTION
To support use of `resource.id` etc.