### PR TITLE
Add RUN_MEMORY_SIZE_TO_CPU_CORES_COEFF constant

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -212,7 +212,7 @@ export const ACTOR_LIMITS = {
     RUN_DISK_TO_MEMORY_SIZE_COEFF: 2,
 
     // For each build or run container, set CPU cores based on memory size
-    RUN_MEMORY_SIZE_TO_CPU_CORES_COEFF: 4096,
+    RUN_MEMORY_MBYTES_PER_CPU_CORE: 4096,
 
     // The default limit of memory for all running Actor jobs for free accounts.
     FREE_ACCOUNT_MAX_MEMORY_MBYTES: 8192,

--- a/src/consts.js
+++ b/src/consts.js
@@ -211,6 +211,9 @@ export const ACTOR_LIMITS = {
     // For each build or run container, set disk quota based on memory size
     RUN_DISK_TO_MEMORY_SIZE_COEFF: 2,
 
+    // For each build or run container, set CPU cores based on memory size
+    RUN_MEMORY_SIZE_TO_CPU_CORES_COEFF: 4096,
+
     // The default limit of memory for all running Actor jobs for free accounts.
     FREE_ACCOUNT_MAX_MEMORY_MBYTES: 8192,
 


### PR DESCRIPTION
Add a constant containing the coefficient for converting the run memory to available CPU cores of the run.

Necessary for [https://bitbucket.org/apifyteam/apify-system/pull-requests/1881](https://bitbucket.org/apifyteam/apify-system/pull-requests/1881).