### PR TITLE
Babel plugin to compile object rest and spread to ES5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,8 @@
         }
       }]
     ],
-    "plugins": ["add-module-exports"]
+    "plugins": [
+        "add-module-exports",
+        "@babel/plugin-proposal-object-rest-spread"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@apify/eslint-config": "0.0.3",
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
     "ajv": "^6.9.2",


### PR DESCRIPTION
On apify.com, we get `SyntaxError: Unexpected token '...'. Expected a property name ` on iOS 11 devices when calling  `defaultLog` from apify-shared/log.

Adding the `@babel/plugin-proposal-object-rest-spread` plugin should fix the issue.

https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread

