### PR TITLE
Fix unwanted whitespace after title text

### DIFF
--- a/src/markdown_renderers.js
+++ b/src/markdown_renderers.js
@@ -21,9 +21,7 @@ export const customHeadingRenderer = (text, level, raw) => {
     const titleText = text.split('{')[0].trim();
 
     const headingToReturn = `
-            <h${level} id="${idTag}">
-                ${titleText}
-            </h${level}>`;
+            <h${level} id="${idTag}">${titleText}</h${level}>`;
 
     return headingToReturn;
 };

--- a/test/markdown_renderers.js
+++ b/test/markdown_renderers.js
@@ -12,24 +12,18 @@ describe('customHeadingRenderer', () => {
     it('uses the custom ID if provided', () => {
         const renderedTitle = marked('# Welcome to Apify {welcome-title-id}');
         expect(renderedTitle).to.equal(`
-            <h1 id="welcome-title-id">
-                Welcome to Apify
-            </h1>`);
+            <h1 id="welcome-title-id">Welcome to Apify</h1>`);
     });
 
     it('generates ID from text if no ID provided', () => {
         const renderedTitle = marked('## Welcome to Apify');
         expect(renderedTitle).to.eql(`
-            <h2 id="welcome-to-apify">
-                Welcome to Apify
-            </h2>`);
+            <h2 id="welcome-to-apify">Welcome to Apify</h2>`);
     });
 
     it('trims whitespace, inserts dashes between words, converts to lowercase, removes punctuation and trailing dash', () => {
         const renderedTitle = marked('# Welcome to Apify { #  .Welcome -title-id . - ? -}');
         expect(renderedTitle).to.eql(`
-            <h1 id="welcome-title-id">
-                Welcome to Apify
-            </h1>`);
+            <h1 id="welcome-title-id">Welcome to Apify</h1>`);
     });
 });


### PR DESCRIPTION
The title text was being generated with a lot of unwanted whitespace at the end. 
@vbartonicek says it's not urgent, so fixed for next package release